### PR TITLE
Recent updates removed `bin/`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+*       @Cray-HPE/metal

--- a/Makefile
+++ b/Makefile
@@ -192,8 +192,8 @@ clean:
 	  $(CURDIR)/build/results/coverage/* \
 	  $(CURDIR)/build/results/unittest/*
 	rm -rf \
-	  bin \
-	  $(BUILD_DIR)
+	  $(binaries) \
+	  $(NAME)-$(GOOS)-$(GOARCH)$(exe)
 
 test: tools
 	mkdir -pv $(TEST_OUTPUT_DIR)/unittest $(TEST_OUTPUT_DIR)/coverage

--- a/Makefile
+++ b/Makefile
@@ -174,7 +174,7 @@ endif
 binaries := ${NAME}
 
 .PHONY: build
-build: tidy $(addprefix bin/,$(binaries))
+build: tidy $(binaries)
 
 go_build := $(go_path) go build $(go_flags) -ldflags '$(go_ldflags)' -o
 

--- a/README.adoc
+++ b/README.adoc
@@ -67,6 +67,6 @@ grep -oP pattern /etc/hosts | tr -s '\n' ' ' | gru show system
 
 [source,bash]
 ----
-make bin/gru
-./bin/gru
+make gru
+./gru
 ----


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
The `bin/` directory isn't used anymore for the sake of the GitHub publishing action. Two places were neglected in the removal of `bin/`.

- Parts of the `Makefile`
- `README.adoc`

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
