### PR TITLE
Add `--now` to `chassis boot`

### DIFF
--- a/pkg/cmd/cli/bios/get.go
+++ b/pkg/cmd/cli/bios/get.go
@@ -38,7 +38,7 @@ import (
 func NewGetCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "get [key[,keyN]]",
-		Short: "Gets BIOS settings by key-name, or get every key.",
+		Short: "Gets BIOS settings by key-name, or get every key",
 		Long:  `Gets BIOS settings.`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)

--- a/pkg/cmd/cli/bios/set.go
+++ b/pkg/cmd/cli/bios/set.go
@@ -38,7 +38,7 @@ import (
 func NewSetCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "set attribute=value[,keyN=valueN]",
-		Short: "Sets BIOS attributes.",
+		Short: "Sets BIOS attributes",
 		Long:  `Sets BIOS attributes if the attribute is found and the value is valid.`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)

--- a/pkg/cmd/cli/boot/chassis.go
+++ b/pkg/cmd/cli/boot/chassis.go
@@ -37,7 +37,7 @@ import (
 func NewChassisCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "boot [flags] host [...host]",
-		Short: "Set next boot device.",
+		Short: "Set next boot device",
 		Long:  `Overrides the next boot device for a one-time override. Only sets UEFI boot modes.`,
 		Run: func(c *cobra.Command, args []string) {
 			v := viper.GetViper()

--- a/pkg/cmd/cli/boot/chassis.go
+++ b/pkg/cmd/cli/boot/chassis.go
@@ -63,5 +63,14 @@ func NewChassisCommand() *cobra.Command {
 		),
 	)
 
+	c.PersistentFlags().BoolP(
+		"now",
+		"n",
+		false,
+		fmt.Sprintln(
+			"Reset the server(s) immediately after applying the boot override.",
+		),
+	)
+
 	return c
 }

--- a/pkg/cmd/cli/boot/override.go
+++ b/pkg/cmd/cli/boot/override.go
@@ -29,6 +29,7 @@ package boot
 import (
 	"github.com/Cray-HPE/gru/pkg/cmd"
 	"github.com/Cray-HPE/gru/pkg/cmd/cli"
+	"github.com/Cray-HPE/gru/pkg/cmd/cli/power"
 	"github.com/Cray-HPE/gru/pkg/set"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
@@ -50,6 +51,10 @@ func NewBootBiosOverrideCommand() *cobra.Command {
 
 			content := set.Async(issueOverride, hosts, redfish.BiosSetupBootSourceOverrideTarget)
 			cli.MapPrint(content)
+			if v.GetBool("now") {
+				content = set.Async(power.Issue, hosts, redfish.ForceRestartResetType)
+				cli.MapPrint(content)
+			}
 		},
 	}
 	return c

--- a/pkg/cmd/cli/boot/override.go
+++ b/pkg/cmd/cli/boot/override.go
@@ -40,7 +40,7 @@ import (
 func NewBootBiosOverrideCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "bios host [...host]",
-		Short: "Boot to BIOS.",
+		Short: "Boot to BIOS",
 		Long:  `Override the next boot with the BIOS option.`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
@@ -64,7 +64,7 @@ func NewBootBiosOverrideCommand() *cobra.Command {
 func NewBootPxeOverrideCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "pxe host [...host]",
-		Short: "Boot with PXE.",
+		Short: "Boot with PXE",
 		Long:  `Override the next boot with the PXE option.`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
@@ -79,7 +79,7 @@ func NewBootPxeOverrideCommand() *cobra.Command {
 func NewBootHddOverrideCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "hdd host [...host]",
-		Short: "Boot from the HDD.",
+		Short: "Boot from the HDD",
 		Long:  `Override the next boot with the HDD option.`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
@@ -94,7 +94,7 @@ func NewBootHddOverrideCommand() *cobra.Command {
 func NewBootUEFIHttpOverrideCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "http host [...host]",
-		Short: "Boot with HTTP.",
+		Short: "Boot with HTTP",
 		Long:  `Override the next boot with the HTTP option.`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
@@ -109,7 +109,7 @@ func NewBootUEFIHttpOverrideCommand() *cobra.Command {
 func NewBootNoneOverrideCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "none host [...host]",
-		Short: "Clear the boot override.",
+		Short: "Clear the boot override",
 		Long:  `Clears a boot override.`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)

--- a/pkg/cmd/cli/chassis/chassis.go
+++ b/pkg/cmd/cli/chassis/chassis.go
@@ -37,7 +37,7 @@ func NewCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:                   "chassis",
 		DisableFlagsInUseLine: true,
-		Short:                 "Chassis control.",
+		Short:                 "Chassis control",
 		Long:                  `Interact with a host's chassis.`,
 		Hidden:                false,
 	}

--- a/pkg/cmd/cli/disks/show.go
+++ b/pkg/cmd/cli/disks/show.go
@@ -34,7 +34,7 @@ import (
 func NewShowCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "disks [flags] host [...host]",
-		Short: "Disk device information.",
+		Short: "Disk device information",
 		Long:  `Show available disk devices.`,
 		Run: func(c *cobra.Command, args []string) {
 		},

--- a/pkg/cmd/cli/get/get.go
+++ b/pkg/cmd/cli/get/get.go
@@ -35,7 +35,7 @@ import (
 func NewCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "get",
-		Short: "Shortcut for getting certain information from RedFish.",
+		Short: "Shortcut for getting certain information from RedFish",
 		Long:  `Shortcut for getting certain information from RedFish.`,
 		Run: func(c *cobra.Command, args []string) {
 		},

--- a/pkg/cmd/cli/power/cycle.go
+++ b/pkg/cmd/cli/power/cycle.go
@@ -57,7 +57,7 @@ Also allows bypassing the OS shutdown, forcing a warm boot.`,
 				resetType = redfish.ForceRestartResetType
 			}
 
-			content := set.Async(issue, hosts, resetType)
+			content := set.Async(Issue, hosts, resetType)
 			cli.MapPrint(content)
 		},
 		Hidden: false,

--- a/pkg/cmd/cli/power/cycle.go
+++ b/pkg/cmd/cli/power/cycle.go
@@ -40,7 +40,7 @@ import (
 func NewPowerCycleCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "cycle",
-		Short: "Power cycle the target machine(s).",
+		Short: "Power cycle the target machine(s)",
 		Long: `Performs an ACPI shutdown and startup to power cycle the target machine(s).
 Also allows bypassing the OS shutdown, forcing a warm boot.`,
 		Run: func(c *cobra.Command, args []string) {

--- a/pkg/cmd/cli/power/nmi.go
+++ b/pkg/cmd/cli/power/nmi.go
@@ -37,7 +37,7 @@ import (
 func NewPowerNMICommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "nmi",
-		Short: "Issue an NMI to the target machine(s).",
+		Short: "Issue an NMI to the target machine(s)",
 		Long:  `Issue a non-maskable interrupt, triggering a crash/core dump.`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)

--- a/pkg/cmd/cli/power/nmi.go
+++ b/pkg/cmd/cli/power/nmi.go
@@ -41,7 +41,7 @@ func NewPowerNMICommand() *cobra.Command {
 		Long:  `Issue a non-maskable interrupt, triggering a crash/core dump.`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
-			content := set.Async(issue, hosts, redfish.NmiResetType)
+			content := set.Async(Issue, hosts, redfish.NmiResetType)
 			cli.MapPrint(content)
 		},
 		Hidden: false,

--- a/pkg/cmd/cli/power/off.go
+++ b/pkg/cmd/cli/power/off.go
@@ -61,7 +61,7 @@ as well as a power-button emulated shutdown.`,
 				resetType = redfish.PushPowerButtonResetType
 			}
 
-			content := set.Async(issue, hosts, resetType)
+			content := set.Async(Issue, hosts, resetType)
 			cli.MapPrint(content)
 		},
 	}

--- a/pkg/cmd/cli/power/off.go
+++ b/pkg/cmd/cli/power/off.go
@@ -40,7 +40,7 @@ import (
 func NewPowerOffCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "off",
-		Short: "Power off the target machine(s).",
+		Short: "Power off the target machine(s)",
 		Long: `Powers off the target machine(s) with an ACPI shutdown.
 Permits forcing a shutdown (without waiting for the OS),
 as well as a power-button emulated shutdown.`,

--- a/pkg/cmd/cli/power/on.go
+++ b/pkg/cmd/cli/power/on.go
@@ -37,7 +37,7 @@ import (
 func NewPowerOnCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "on",
-		Short: "Power on the target machine(s).",
+		Short: "Power on the target machine(s)",
 		Long:  `Powers on the target machines (cold boot).`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)

--- a/pkg/cmd/cli/power/on.go
+++ b/pkg/cmd/cli/power/on.go
@@ -41,7 +41,7 @@ func NewPowerOnCommand() *cobra.Command {
 		Long:  `Powers on the target machines (cold boot).`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
-			content := set.Async(issue, hosts, redfish.OnResetType)
+			content := set.Async(Issue, hosts, redfish.OnResetType)
 			cli.MapPrint(content)
 		},
 	}

--- a/pkg/cmd/cli/power/power.go
+++ b/pkg/cmd/cli/power/power.go
@@ -44,8 +44,8 @@ type State struct {
 	Error      error              `json:"error,omitempty"`
 }
 
-// issue issues an action against a host.
-func issue(host string, action interface{}) interface{} {
+// Issue issues an action against a host.
+func Issue(host string, action interface{}) interface{} {
 	sc := StateChange{}
 	c, err := auth.Connection(host)
 	if err != nil {

--- a/pkg/cmd/cli/power/reset.go
+++ b/pkg/cmd/cli/power/reset.go
@@ -37,7 +37,7 @@ import (
 func NewPowerResetCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "reset",
-		Short: "Power reset the target machine(s).",
+		Short: "Power reset the target machine(s)",
 		Long:  `Forcefully restart the target machine(s) without a graceful shutdown.`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)

--- a/pkg/cmd/cli/power/reset.go
+++ b/pkg/cmd/cli/power/reset.go
@@ -41,7 +41,7 @@ func NewPowerResetCommand() *cobra.Command {
 		Long:  `Forcefully restart the target machine(s) without a graceful shutdown.`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
-			content := set.Async(issue, hosts, redfish.ForceRestartResetType)
+			content := set.Async(Issue, hosts, redfish.ForceRestartResetType)
 			cli.MapPrint(content)
 		},
 		Hidden: false,

--- a/pkg/cmd/cli/power/status.go
+++ b/pkg/cmd/cli/power/status.go
@@ -36,7 +36,7 @@ import (
 func NewPowerStatusCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "status",
-		Short: "Power status for the target machine(s).",
+		Short: "Power status for the target machine(s)",
 		Long:  `Prints the current power status reported by the blade management controller for the target machine(s).`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)

--- a/pkg/cmd/cli/show/show.go
+++ b/pkg/cmd/cli/show/show.go
@@ -39,7 +39,7 @@ func NewCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:                   "show",
 		DisableFlagsInUseLine: true,
-		Short:                 "Curated server information.",
+		Short:                 "Curated server information",
 		Long:                  `Print pre-defined classes of information from one or more BMCs.`,
 		Run: func(c *cobra.Command, args []string) {
 		},

--- a/pkg/cmd/cli/system/show.go
+++ b/pkg/cmd/cli/system/show.go
@@ -37,7 +37,7 @@ import (
 func NewShowCommand() *cobra.Command {
 	c := &cobra.Command{
 		Use:   "system [flags] host [...host]",
-		Short: "System information.",
+		Short: "System information",
 		Long:  `Show the Server Manufacturer, Server Model, System Version, and Firmware Version for the given server(s).`,
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)

--- a/pkg/cmd/gru/gru.go
+++ b/pkg/cmd/gru/gru.go
@@ -74,20 +74,20 @@ the YAML file may provide these per host.
 		"c",
 		fmt.Sprintf("./%s.yml", name),
 		fmt.Sprintln(
-			"Configuration file containing BMC credentials, necessary if USERNAME and PASSWORD are not defined in the environment.",
+			"Configuration file containing BMC credentials, necessary if USERNAME and PASSWORD are not defined in the environment",
 			name,
 		),
 	)
 	c.PersistentFlags().Bool(
 		"insecure",
 		false,
-		"Ignore untrusted or insecure certificates.",
+		"Ignore untrusted or insecure certificates",
 	)
 	c.PersistentFlags().BoolP(
 		"json",
 		"j",
 		false,
-		"Output results in JSON.",
+		"Output results in JSON",
 	)
 	c.AddCommand(
 		chassis.NewCommand(),


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Adds the ability to reset the target server(s) immediately after applying a boot option override.

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
