### PR TITLE
Add dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,13 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+      - "gomod"
   - package-ecosystem: "github-actions"
     # Look for `.github/workflows` in the `root` directory
     directory: "/"
     # Check for updates once a week
     schedule:
       interval: "weekly"
+    labels:
+      - "dependencies"
+      - "github_actions"


### PR DESCRIPTION
Add *gomod* or *github_actions* depending on the dependabot focus.
