### PR TITLE
Fixes #30 `GitTreeState` is always "dirty" when building from GitHub Actions

### DIFF
--- a/.github/workflows/promote-prerelease.yml
+++ b/.github/workflows/promote-prerelease.yml
@@ -53,6 +53,7 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           goversion: ${{ env.GO_VERSION }}
+          pre_command: "rm -f go-*.tar.gz"
           build_command: "make ${{ env.REPO_NAME }}"
           release_tag: ${{ env.TAG }}
           md5sum: 'FALSE'

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -51,6 +51,7 @@ jobs:
           goos: ${{ matrix.goos }}
           goarch: ${{ matrix.goarch }}
           goversion: ${{ env.GO_VERSION }}
+          pre_command: "rm -f go-*.tar.gz"
           build_command: "make ${{ env.REPO_NAME }}"
           release_tag: ${{ env.TAG }}
           md5sum: 'FALSE'

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/viper v1.17.0
 	github.com/stmcginnis/gofish v0.14.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -53,5 +54,4 @@ require (
 	golang.org/x/sys v0.12.0 // indirect
 	golang.org/x/text v0.13.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->

- Fixes: #30 
- Relates to: https://github.com/wangyoucao577/go-release-action/issues/143

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This works around https://github.com/wangyoucao577/go-release-action/issues/143 by removing the downloaded Go source code before running `make`. The downloaded source code was triggering `git status -s` to report the repository as dirty. I ran a debug build that shows `go-linux.tar.gz` as the culprit:
- [Line 218](https://github.com/Cray-HPE/gru/actions/runs/7063185458/job/19228607307#step:5:218) shows `go-linux.tar.gz` appearing in `git status -s` 
- [Line 241](https://github.com/Cray-HPE/gru/actions/runs/7063185458/job/19228607307#step:5:241) shows the `LDFLAG` reporting the undesired value of "dirty": `github.com/Cray-HPE/gru/pkg/version.GitTreeState='dirty''`

After resolving that and testing a bogus v0.0.5a2 tag, I observed a "clean" `GitTreeState`:
- [line 217](https://github.com/Cray-HPE/gru/actions/runs/7063265071/job/19228853733#step:5:217) shows removal of the downloaded source tar
- [Line 241](https://github.com/Cray-HPE/gru/actions/runs/7063265071/job/19228853733#step:5:241) shows the `LDFLAG` reporting the desired "clean" value: `github.com/Cray-HPE/gru/pkg/version.GitTreeState='clean'`

I've made an [upstream PR](https://github.com/wangyoucao577/go-release-action/pull/144), but in the meantime (or in case it never merges) we can fix this by just removing the downloaded file.

This also fixes a non-issue, where the current `go.mod` file needed `go mod tidy` ran. `make` invokes `go mod tidy` which does modify `go.mod` with the current HEAD, however this does NOT cause the problem. `GitTreeState` is resolved _before_ `go mod tidy` is invoked during `make`, however it's kosher/proper to clean this up regardless.

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
This will fix official release's version strings, giving more confidence that the app was built cleanly.
