### PR TITLE
Post fixes

### DIFF
--- a/pkg/cmd/cli/bios/bios.go
+++ b/pkg/cmd/cli/bios/bios.go
@@ -163,7 +163,7 @@ func getSystemBios(host string) (systems []*redfish.ComputerSystem, bios *redfis
 	// get the systems
 	service := c.Service
 	systems, err = service.Systems()
-	if err != nil {
+	if err != nil || len(systems) < 1 {
 		return systems, bios, err
 	}
 

--- a/pkg/cmd/cli/bios/bios.go
+++ b/pkg/cmd/cli/bios/bios.go
@@ -59,7 +59,6 @@ func NewCommand() *cobra.Command {
 		Short:            "BIOS interaction",
 		Long:             `Interact with a host's bios`,
 		TraverseChildren: true,
-		Args:             cobra.MinimumNArgs(1),
 		Hidden:           false,
 		Run: func(c *cobra.Command, args []string) {
 		},

--- a/pkg/cmd/cli/bios/get.go
+++ b/pkg/cmd/cli/bios/get.go
@@ -47,7 +47,6 @@ func NewBiosGetCommand() *cobra.Command {
 		Use:   "get host [...host]",
 		Short: "Gets BIOS attributes by key-name, or get all attributes",
 		Long:  `Gets BIOS attributes`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := query.Async(getBiosAttributes, hosts)

--- a/pkg/cmd/cli/bios/set.go
+++ b/pkg/cmd/cli/bios/set.go
@@ -44,7 +44,6 @@ func NewBiosSetCommand() *cobra.Command {
 		Use:   "set host [...host]",
 		Short: "Sets BIOS attributes",
 		Long:  `Sets BIOS attributes if the attribute is found and the value is valid.`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			if len(Attributes) == 0 && FromFile == "" && !collections.Virtualization && !ClearCmos {
 				_, err := fmt.Fprintln(

--- a/pkg/cmd/cli/bios/set.go
+++ b/pkg/cmd/cli/bios/set.go
@@ -100,7 +100,7 @@ func setBios(host string, requestedAttributes map[string]interface{}) interface{
 	v := viper.GetViper()
 
 	systems, bios, err := getSystemBios(host)
-	if err != nil {
+	if err != nil || len(systems) < 1 {
 		attributes.Error = err
 		return attributes
 	}

--- a/pkg/cmd/cli/chassis/boot/boot.go
+++ b/pkg/cmd/cli/chassis/boot/boot.go
@@ -100,7 +100,7 @@ func issueOverride(host string, override interface{}) interface{} {
 	service := c.Service
 
 	systems, err := service.Systems()
-	if err != nil {
+	if err != nil || len(systems) < 1 {
 		o.Error = err
 		return o
 	}

--- a/pkg/cmd/cli/chassis/boot/override.go
+++ b/pkg/cmd/cli/chassis/boot/override.go
@@ -42,7 +42,6 @@ func NewBiosOverrideCommand() *cobra.Command {
 		Use:   "bios host [...host]",
 		Short: "Boot to BIOS",
 		Long:  `Override the next boot with the BIOS option`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 
@@ -67,7 +66,6 @@ func NewPxeOverrideCommand() *cobra.Command {
 		Use:   "pxe host [...host]",
 		Short: "Boot with PXE",
 		Long:  `Override the next boot with the PXE option`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(issueOverride, hosts, redfish.PxeBootSourceOverrideTarget)
@@ -83,7 +81,6 @@ func NewHddOverrideCommand() *cobra.Command {
 		Use:   "hdd host [...host]",
 		Short: "Boot from the HDD",
 		Long:  `Override the next boot with the HDD option`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(issueOverride, hosts, redfish.HddBootSourceOverrideTarget)
@@ -99,7 +96,6 @@ func NewUEFIHttpOverrideCommand() *cobra.Command {
 		Use:   "http host [...host]",
 		Short: "Boot with HTTP",
 		Long:  `Override the next boot with the HTTP option`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(issueOverride, hosts, redfish.UefiHTTPBootSourceOverrideTarget)
@@ -115,7 +111,6 @@ func NewNoneOverrideCommand() *cobra.Command {
 		Use:   "none host [...host]",
 		Short: "Clear the boot override",
 		Long:  `Clears a boot override`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(issueOverride, hosts, redfish.NoneBootSourceOverrideTarget)

--- a/pkg/cmd/cli/chassis/boot/show.go
+++ b/pkg/cmd/cli/chassis/boot/show.go
@@ -45,7 +45,6 @@ func NewShowCommand() *cobra.Command {
 		Use:   "boot host [...host]",
 		Short: "Boot information",
 		Long:  `Show the current BootOrder; BootNext, networkRetry, and more`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := query.Async(getBootInformation, hosts)

--- a/pkg/cmd/cli/chassis/boot/show.go
+++ b/pkg/cmd/cli/chassis/boot/show.go
@@ -67,7 +67,7 @@ func getBootInformation(host string) interface{} {
 	service := c.Service
 
 	systems, err := service.Systems()
-	if err != nil {
+	if err != nil || len(systems) < 1 {
 		boot.Error = err
 		return boot
 	}

--- a/pkg/cmd/cli/chassis/power/nmi.go
+++ b/pkg/cmd/cli/chassis/power/nmi.go
@@ -39,7 +39,6 @@ func NewPowerNMICommand() *cobra.Command {
 		Use:   "nmi host [...host]",
 		Short: "Issue an NMI to the target machine(s)",
 		Long:  `Issue a non-maskable interrupt, triggering a crash/core dump`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(Issue, hosts, redfish.NmiResetType)

--- a/pkg/cmd/cli/chassis/power/on.go
+++ b/pkg/cmd/cli/chassis/power/on.go
@@ -39,7 +39,6 @@ func NewPowerOnCommand() *cobra.Command {
 		Use:   "on host [...host]",
 		Short: "Power on the target machine(s)",
 		Long:  `Powers on the target machines (cold boot)`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(Issue, hosts, redfish.OnResetType)

--- a/pkg/cmd/cli/chassis/power/power.go
+++ b/pkg/cmd/cli/chassis/power/power.go
@@ -77,7 +77,7 @@ func Issue(host string, action interface{}) interface{} {
 	service := c.Service
 
 	systems, err := service.Systems()
-	if err != nil {
+	if err != nil || len(systems) < 1 {
 		sc.Error = err
 		return sc
 	}

--- a/pkg/cmd/cli/chassis/power/reset.go
+++ b/pkg/cmd/cli/chassis/power/reset.go
@@ -39,7 +39,6 @@ func NewPowerResetCommand() *cobra.Command {
 		Use:   "reset host [...host]",
 		Short: "Power reset the target machine(s)",
 		Long:  `Forcefully restart the target machine(s) without a graceful shutdown`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(Issue, hosts, redfish.ForceRestartResetType)

--- a/pkg/cmd/cli/chassis/power/status.go
+++ b/pkg/cmd/cli/chassis/power/status.go
@@ -62,7 +62,7 @@ func status(host string) interface{} {
 	service := c.Service
 
 	systems, err := service.Systems()
-	if err != nil {
+	if err != nil || len(systems) < 1 {
 		s.Error = err
 		return s
 	}

--- a/pkg/cmd/cli/chassis/power/status.go
+++ b/pkg/cmd/cli/chassis/power/status.go
@@ -39,7 +39,6 @@ func NewPowerStatusCommand() *cobra.Command {
 		Use:   "status host [...host]",
 		Short: "Power status for the target machine(s)",
 		Long:  `Prints the current power status reported by the blade management controller for the target machine(s)`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := query.Async(status, hosts)

--- a/pkg/cmd/cli/cli.go
+++ b/pkg/cmd/cli/cli.go
@@ -121,6 +121,14 @@ func ParseHosts(args []string) []string {
 		}
 		return newArgs
 	}
+	if len(args) < 1 {
+		err := fmt.Errorf("no hosts given")
+		if _, exc := fmt.Fprintln(os.Stderr, err); exc != nil {
+
+			panic(exc)
+		}
+		os.Exit(1)
+	}
 	return args
 }
 

--- a/pkg/cmd/cli/system/show.go
+++ b/pkg/cmd/cli/system/show.go
@@ -39,7 +39,6 @@ func NewShowCommand() *cobra.Command {
 		Use:   "system host [...host]",
 		Short: "System information",
 		Long:  `Show the Server Manufacturer, Server Model, System Version, and Firmware Version for the given server(s)`,
-		Args:  cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := query.Async(getSystemInformation, hosts)

--- a/pkg/cmd/cli/system/show.go
+++ b/pkg/cmd/cli/system/show.go
@@ -60,15 +60,16 @@ func getSystemInformation(host string) interface{} {
 	service := c.Service
 
 	managers, err := service.Managers()
-	if err != nil {
+	if err != nil || len(managers) < 1 {
 		system.Error = err
-	} else {
-		system.FirmwareVersion = managers[0].FirmwareVersion
+		return system
 	}
+	system.FirmwareVersion = managers[0].FirmwareVersion
 
 	systems, err := service.Systems()
-	if err != nil {
+	if err != nil || len(systems) < 1 {
 		system.Error = err
+		return system
 	}
 	system.Manufacturer = systems[0].Manufacturer
 	system.Model = systems[0].Model

--- a/spec/functional/empty_spec.sh
+++ b/spec/functional/empty_spec.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env sh
+# MIT License
+#
+# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+
+Describe 'gru <empty>'
+
+# no hosts should exit
+It "--config ${GRU_CONF} show system"
+  When call ./gru show system --config "${GRU_CONF}"
+  The status should equal 1
+  The stderr should include 'no hosts given'
+End
+
+End


### PR DESCRIPTION
Release candidate fixes.

- piped args broke again due to 95678a2c50c7a4fe03a8bf4a73c9f1d538673566
- Fix panic when a RedFish endpoint has an error, prevent invalid array access
- Validate a host argument is given