### PR TITLE
Fix tests

### DIFF
--- a/spec/functional/bios_get_attributes_spec.sh
+++ b/spec/functional/bios_get_attributes_spec.sh
@@ -30,7 +30,8 @@ It "--config ${GRU_CONF} --attributes BootTimeout 127.0.0.1:5000"
   When call ./gru bios get --config "${GRU_CONF}" --attributes BootTimeout 127.0.0.1:5000
   The status should equal 0
   The stdout should include 'BootTimeout'
-  The lines of stdout should equal 4
+  The lines of stdout should equal 3
+  The lines of stderr should equal 1
 End
 
 # getting a single key should return only those key in json
@@ -39,6 +40,7 @@ It "--config ${GRU_CONF} --attributes BootTimeout 127.0.0.1:5000 --json"
   The status should equal 0
   The stdout should include 'BootTimeout'
   The stdout should be_json
+  The lines of stderr should equal 0
 End
 
 # getting multiple keys should return only those keys
@@ -47,7 +49,8 @@ It "--config ${GRU_CONF} --attributes ProcessorHyperThreadingDisable,SRIOVEnable
   The status should equal 0
   The stdout should include 'ProcessorHyperThreadingDisable'
   The stdout should include 'SRIOVEnable'
-  The lines of stdout should equal 4
+  The lines of stdout should equal 3
+  The lines of stderr should equal 1
 End
 
 # getting specific keys should return only those keys and should be json
@@ -57,15 +60,17 @@ It "--config ${GRU_CONF} --attributes ProcessorHyperThreadingDisable,SRIOVEnable
   The stdout should include 'ProcessorHyperThreadingDisable'
   The stdout should include 'SRIOVEnable'
   The stdout should be_json
+  The lines of stderr should equal 0
 End
 
 # it should error if no matching keys were found
 It "--config ${GRU_CONF} --attributes junk 127.0.0.1:5000"
   When call ./gru bios get --config "${GRU_CONF}" --attributes junk 127.0.0.1:5000
   The status should equal 0
-  The line 4 of stdout should include 'junk'
-  The line 4 of stdout should include '<nil>'
-  The lines of stdout should equal 4
+  The line 3 of stdout should include 'junk'
+  The line 3 of stdout should include '<nil>'
+  The lines of stdout should equal 3
+  The lines of stderr should equal 1
 End
 
 # TODO: restore when args work with piping
@@ -85,7 +90,8 @@ It "--config ${GRU_CONF} --virtualization 127.0.0.1:5001"
   The stdout should include 'Local APIC Mode'
   The stdout should include 'IOMMU'
   The stdout should include 'SVM Mode'
-  The lines of stdout should equal 8
+  The lines of stdout should equal 7
+  The lines of stderr should equal 1
 End
 
 # --virtualization shortcut should return only virtualization attributes in json format (Gigabyte)
@@ -98,6 +104,7 @@ It "--config ${GRU_CONF} --virtualization 127.0.0.1:5001 --json"
   The stdout should include 'Rome0162' # 'IOMMU'
   The stdout should include 'Rome0565' # 'SVM Mode'
   The stdout should be_json
+  The lines of stderr should equal 0
 End
 
 # Gigabyte should return friendly names on non-json output
@@ -109,7 +116,8 @@ It "--config ${GRU_CONF} 127.0.0.1:5001"
   The stdout should include 'Disable Block Sid'
   The stdout should include 'Rome0179'
   The stdout should include 'Determinism Slider'
-  The lines of stdout should equal 553
+  The lines of stdout should equal 552
+  The lines of stderr should equal 1
 End
 
 # Gigabyte should not return friendly names on json output
@@ -124,6 +132,7 @@ It "--config ${GRU_CONF} 127.0.0.1:5001 --json"
   The stdout should include 'Disabled'
   The stdout should not include 'Determinism Slider'
   The stdout should be_json
+  The lines of stderr should equal 0
 End
 
 End

--- a/spec/functional/bios_get_spec.sh
+++ b/spec/functional/bios_get_spec.sh
@@ -35,7 +35,8 @@ It "--config ${GRU_CONF} 127.0.0.1:5000"
   The stdout should include 'ProcessorHyperThreadingDisable'
   The stdout should include 'SRIOVEnable'
   The stdout should include 'VTdSupport'
-  The lines of stdout should equal 867
+  The lines of stdout should equal 866
+  The lines of stderr should equal 1
 End
 
 # TODO: restore when args work with piping
@@ -52,7 +53,8 @@ It "--config ${GRU_CONF} --pending 127.0.0.1:5000"
   The status should equal 0
   The stdout should include 'Error'
   The stdout should include '"Attributes" does not exist or is null, the BIOS/firmware may need to updated for proper Attributes support'
-  The lines of stdout should equal 3
+  The lines of stdout should equal 2
+  The lines of stderr should equal 1
 End
 
 # TODO: restore when marshaling JSON errors is fixed.
@@ -63,6 +65,7 @@ End
 #  The stdout should include 'error'
 #  The stdout should include '\"Attributes\" does not exist or is null, the BIOS/firmware may need to updated for proper Attributes support'
 #  The stdout should be_json
+#  The lines of stderr should equal 0
 #End
 
 # getting keys from a file should return those keys
@@ -71,7 +74,8 @@ It "--config ${GRU_CONF} --from-file ${GRU_BIOS_KV} 127.0.0.1:5000"
   The status should equal 0
   The stdout should include 'BootTimeout'
   The stdout should include 'SRIOVEnable'
-  The lines of stdout should equal 5
+  The lines of stdout should equal 4
+  The lines of stderr should equal 1
 End
 
 # getting keys from a file should return those keys and be valid json
@@ -81,6 +85,7 @@ It "--config ${GRU_CONF} --from-file ${GRU_BIOS_KV} 127.0.0.1:5000 --json"
   The stdout should include 'BootTimeout'
   The stdout should include 'SRIOVEnable'
   The stdout should be_json
+  The lines of stderr should equal 0
 End
 
 # passing a shortcut should return a limited set of pre-defined keys
@@ -90,7 +95,8 @@ It "--config ${GRU_CONF} --virtualization 127.0.0.1:5003"
   The stdout should include 'ProcAmdIOMMU'
   The stdout should include 'Sriov'
   The stdout should include 'ProcAmdVirtualization'
-  The lines of stdout should equal 7
+  The lines of stdout should equal 6
+  The lines of stderr should equal 1
 End
 
 # passing a shortcut should return a limited set of pre-defined keys and be valid json
@@ -101,6 +107,7 @@ It "--config ${GRU_CONF} --virtualization 127.0.0.1:5003 --json"
   The stdout should include 'ProcAmdVirtualization'
   The stdout should include 'Sriov'
   The stdout should be_json
+  The lines of stderr should equal 0
 End
 
 # piping in hosts should also work
@@ -115,6 +122,7 @@ Describe 'validate STDIN works'
     The stdout should include 'ProcAmdVirtualization'
     The stdout should include 'Sriov'
     The stdout should be_json
+    The lines of stderr should equal 0
   End
 End
 

--- a/spec/functional/bios_set_attributes_spec.sh
+++ b/spec/functional/bios_set_attributes_spec.sh
@@ -31,7 +31,8 @@ BeforeAll use_valid_config
 #   When call ./gru bios set --config "${GRU_CONF}" --attributes ProcessorHyperThreadingDisable=0,SRIOVEnable=0 127.0.0.1:5000
 #   The status should equal 0
 #   The stdout should include 'BIOS change(s) may be applied at: ["Immediate","OnReset","AtMaintenanceWindowStart","InMaintenanceWindowOnReset"]'
-#   The lines of stdout should equal 3
+#   The lines of stdout should equal 2
+#   The lines of stderr should equal 1
 # End
 
 # TODO: restore when args work with piping

--- a/spec/functional/bios_set_spec.sh
+++ b/spec/functional/bios_set_spec.sh
@@ -33,6 +33,7 @@ It "--config ${GRU_CONF} 127.0.0.1:5000"
   The status should equal 1
   The stderr should include 'an error occurred: at least one of the flags in the group [attributes from-file virtualization clear-cmos] is required'
   The stdout should include "Usage:"
+  The lines of stderr should equal 1
 End
 
 # setting with more than one flag should fail
@@ -41,6 +42,7 @@ It "--config ${GRU_CONF} 127.0.0.1:5000"
   The status should equal 1
   The stderr should include 'an error occurred: only one of the flags in the group [attributes from-file virtualization clear-cmos] can be specified at a time'
   The stdout should include "Usage:"
+  The lines of stderr should equal 1
 End
 
 # TODO: restore when args work with piping
@@ -49,6 +51,7 @@ End
 #   When call ./gru --config "${GRU_CONF}" bios set
 #   The status should equal 1
 #   The stderr should include 'Error: requires at least 1 arg(s), only received 0'
+#   The lines of stderr should equal 1
 # End
 
 # FIXME: the emulator does not support PATCH ops.  Once it does, uncomment, adjust if needed
@@ -58,7 +61,8 @@ End
 #   The status should equal 0
 #   The stdout should include 'Error'
 #   The stdout should include 'BIOS reset failure: unable to execute request, no target provided'
-#   The lines of stdout should equal 3
+#   The lines of stdout should equal 2
+#   The lines of stderr should equal 1
 # End
 
 # # restoring defaults and be valid json
@@ -68,6 +72,7 @@ End
 #   The stdout should include 'Error'
 #   The stdout should include 'BIOS reset failure: unable to execute request, no target provided'
 #   The stdout should be_json
+#   The lines of stderr should equal 0
 # End
 
 # # setting keys from a file should return those keys
@@ -84,7 +89,8 @@ End
 #   The stdout should include 'SRIOVEnable'
 #   The stdout should include 'SvrMngmntAcpiIpmi'
 #   The stdout should include 'VTdSupport'
-#   The lines of stdout should equal 3
+#   The lines of stdout should equal 2
+#   The lines of stderr should equal 1
 # End
 
 # # setting keys from a file should return those keys and be valid json
@@ -102,6 +108,7 @@ End
 #   The stdout should include 'SvrMngmntAcpiIpmi'
 #   The stdout should include 'VTdSupport'
 #   The stdout should be_json
+#   The lines of stderr should equal 0
 # End
 
 # # passing a shortcut should return a limited set of pre-defined keys
@@ -115,6 +122,7 @@ End
 #   The stdout should include 'SRIOVEnable'
 #   The stdout should include 'SvrMngmntAcpiIpmi'
 #   The stdout should include 'VTdSupport'
+#   The lines of stderr should equal 1
 # End
 
 # # passing a shortcut should return a limited set of pre-defined keys and be valid json
@@ -129,6 +137,7 @@ End
 #   The stdout should include 'SvrMngmntAcpiIpmi'
 #   The stdout should include 'VTdSupport'
 #   The stdout should be_json
+#   The lines of stderr should equal 0
 # End
 
 End

--- a/spec/functional/chassis_power_off_spec.sh
+++ b/spec/functional/chassis_power_off_spec.sh
@@ -28,8 +28,8 @@ Describe 'gru chassis power off'
 It '127.0.0.1:5000 (no config file)'
   When call ./gru chassis power off 127.0.0.1:5000
   The status should equal 1
-  The line 1 of stdout should include 'Asynchronously updating'
-  The stderr should equal "An error occurred: no credentials provided, please provide a config file or environment variables"
+  The line 1 of stderr should include 'Asynchronously updating'
+  The stderr should include "An error occurred: no credentials provided, please provide a config file or environment variables"
 End
 
 # Running against an active host with good credentials should succeed and show output
@@ -37,13 +37,14 @@ It "--config ${GRU_CONF} 127.0.0.1:5000"
   BeforeCall use_valid_config
   When call ./gru chassis power off --config "${GRU_CONF}" 127.0.0.1:5000
   The status should equal 0
-  The line 1 of stdout should include 'Asynchronously updating'
-  The line 2 of stdout should equal '127.0.0.1:5000:'
-  The line 3 of stdout should include 'PreviousPowerState'
+  The line 1 of stderr should include 'Asynchronously updating'
+  The line 1 of stdout should equal '127.0.0.1:5000:'
+  The line 2 of stdout should include 'PreviousPowerState'
   # powerstate can vary depending when test runs so more logic needed
   # The line 3 of stdout should include 'Off' 
-  The line 4 of stdout should include 'RequestedPowerState'
-  The line 4 of stdout should include 'GracefulShutdown'
+  The line 3 of stdout should include 'RequestedPowerState'
+  The line 3 of stdout should include 'GracefulShutdown'
+  The lines of stderr should equal 1
 End
 
 # immediately check the status of the same node, which should now be off
@@ -51,10 +52,11 @@ It "--config ${GRU_CONF} 127.0.0.1:5000"
   BeforeCall use_valid_config
   When call ./gru chassis power status --config "${GRU_CONF}" 127.0.0.1:5000
   The status should equal 0
-  The line 1 of stdout should include 'Asynchronously querying'
-  The line 2 of stdout should equal '127.0.0.1:5000:'
-  The line 3 of stdout should include 'PowerState'
-  The line 3 of stdout should include 'Off'
+  The line 1 of stderr should include 'Asynchronously querying'
+  The line 1 of stdout should equal '127.0.0.1:5000:'
+  The line 2 of stdout should include 'PowerState'
+  The line 2 of stdout should include 'Off'
+  The lines of stderr should equal 1
 End
 
 End

--- a/spec/functional/chassis_power_on_spec.sh
+++ b/spec/functional/chassis_power_on_spec.sh
@@ -28,8 +28,8 @@ Describe 'gru chassis power on'
 It '127.0.0.1:5000 (no config file)'
   When call ./gru chassis power on 127.0.0.1:5000
   The status should equal 1
-  The line 1 of stdout should include 'Asynchronously updating'
-  The stderr should equal "An error occurred: no credentials provided, please provide a config file or environment variables"
+  The line 1 of stderr should include 'Asynchronously updating'
+  The stderr should include "An error occurred: no credentials provided, please provide a config file or environment variables"
 End
 
 # Running against an active host with good credentials should succeed and report the node is on
@@ -37,13 +37,14 @@ It "--config ${GRU_CONF} 127.0.0.1:5000"
   BeforeCall use_valid_config
   When call ./gru chassis power on --config "${GRU_CONF}" 127.0.0.1:5000
   The status should equal 0
-  The line 1 of stdout should include 'Asynchronously updating'
-  The line 2 of stdout should equal '127.0.0.1:5000:'
-  The line 3 of stdout should include 'PreviousPowerState'
+  The line 1 of stderr should include 'Asynchronously updating'
+  The line 1 of stdout should equal '127.0.0.1:5000:'
+  The line 2 of stdout should include 'PreviousPowerState'
   # powerstate can vary depending when test runs so more logic needed
   # The line 3 of stdout should include 'On'
-  The line 4 of stdout should include 'RequestedPowerState'
-  The line 4 of stdout should include 'On'
+  The line 3 of stdout should include 'RequestedPowerState'
+  The line 3 of stdout should include 'On'
+  The lines of stderr should equal 1
 End
 
 # Running against an active host with good credentials should succeed and report the node is on
@@ -51,8 +52,9 @@ It "--config ${GRU_CONF} 127.0.0.1:5000"
   BeforeCall use_valid_config
   When call ./gru chassis power status --config "${GRU_CONF}" 127.0.0.1:5000
   The status should equal 0
-  The line 1 of stdout should include 'Asynchronously querying'
-  The line 2 of stdout should equal '127.0.0.1:5000:' 
+  The line 1 of stderr should include 'Asynchronously querying'
+  The line 1 of stdout should equal '127.0.0.1:5000:'
+  The lines of stderr should equal 1
 End
 
 End

--- a/spec/functional/chassis_power_status_spec.sh
+++ b/spec/functional/chassis_power_status_spec.sh
@@ -28,8 +28,8 @@ Describe 'gru chassis power status'
 It '127.0.0.1:5000 (no config file)'
   When call ./gru chassis power status 127.0.0.1:5000
   The status should equal 1
-  The line 1 of stdout should include 'Asynchronously querying'
-  The stderr should equal "An error occurred: no credentials provided, please provide a config file or environment variables"
+  The line 1 of stderr should include 'Asynchronously querying'
+  The stderr should include "An error occurred: no credentials provided, please provide a config file or environment variables"
 End
 
 # Running against an active host with good credentials should succeed and report the status
@@ -37,8 +37,8 @@ It "--config ${GRU_CONF} 127.0.0.1:5000"
   BeforeCall use_valid_config
   When call ./gru chassis power status --config "${GRU_CONF}" 127.0.0.1:5000
   The status should equal 0
-  The line 1 of stdout should include 'Asynchronously querying'
-  The line 2 of stdout should equal '127.0.0.1:5000:' 
+  The line 1 of stderr should include 'Asynchronously querying'
+  The line 1 of stdout should equal '127.0.0.1:5000:'
 End
 
 End


### PR DESCRIPTION
PR #44 included an output change for the `set` and `query` modules. These tests require updates to accommodate that change.

Since the PR was from a fork, the tests never ran (and I never bothered to run them locally).

This PR fixes the tests.