### PR TITLE
Adds #42 CPU printout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ gru.y[a?]ml
 gru
 !testdata/fixtures/gru
 gru-*
+csm-redfish-interface-emulator/

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/cmd/gru/main.go
+++ b/cmd/gru/main.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@
 //
 // MIT License
 //
-// (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+// (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
 // copy of this software and associated documentation files (the "Software"),

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/internal/set/set.go
+++ b/internal/set/set.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/cmd/cli/bios/amd/epyc/rome/decoder.go
+++ b/pkg/cmd/cli/bios/amd/epyc/rome/decoder.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/cmd/cli/bios/bios.go
+++ b/pkg/cmd/cli/bios/bios.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/cmd/cli/bios/bios.go
+++ b/pkg/cmd/cli/bios/bios.go
@@ -160,7 +160,6 @@ func getSystemBios(host string) (systems []*redfish.ComputerSystem, bios *redfis
 	}
 	defer c.Logout()
 
-	// get the systems
 	service := c.Service
 	systems, err = service.Systems()
 	if err != nil || len(systems) < 1 {

--- a/pkg/cmd/cli/bios/collections/virtualization.go
+++ b/pkg/cmd/cli/bios/collections/virtualization.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/cmd/cli/bios/get.go
+++ b/pkg/cmd/cli/bios/get.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),
@@ -50,7 +50,7 @@ func NewBiosGetCommand() *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := query.Async(getBiosAttributes, hosts)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 		Hidden: false,
 	}

--- a/pkg/cmd/cli/bios/processors.go
+++ b/pkg/cmd/cli/bios/processors.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/cmd/cli/bios/set.go
+++ b/pkg/cmd/cli/bios/set.go
@@ -1,7 +1,7 @@
 /*
 MIT License
 
-(C) Copyright 2023 Hewlett Packard Enterprise Development LP
+(C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
 Permission is hereby granted, free of charge, to any person obtaining a
 copy of this software and associated documentation files (the "Software"),
@@ -35,7 +35,7 @@ import (
 	"os"
 )
 
-// ClearCmos determins whether or not to clear the CMOS values.
+// ClearCmos determines whether to clear the CMOS values.
 var ClearCmos bool
 
 // NewBiosSetCommand creates the `set` subcommand for `bios`.
@@ -80,7 +80,7 @@ func NewBiosSetCommand() *cobra.Command {
 				content = set.AsyncMap(setBios, hosts, attributes.Attributes)
 			}
 
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 		Hidden: false,
 	}

--- a/pkg/cmd/cli/chassis/boot/boot.go
+++ b/pkg/cmd/cli/chassis/boot/boot.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/cmd/cli/chassis/boot/override.go
+++ b/pkg/cmd/cli/chassis/boot/override.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),
@@ -50,10 +50,10 @@ func NewBiosOverrideCommand() *cobra.Command {
 			cmd.CheckError(bindErr)
 
 			content := set.Async(issueOverride, hosts, redfish.BiosSetupBootSourceOverrideTarget)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 			if v.GetBool("now") {
 				content = set.Async(power.Issue, hosts, redfish.ForceRestartResetType)
-				cli.MapPrint(content)
+				cli.PrettyPrint(content)
 			}
 		},
 	}
@@ -69,7 +69,7 @@ func NewPxeOverrideCommand() *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(issueOverride, hosts, redfish.PxeBootSourceOverrideTarget)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 	}
 	return c
@@ -84,7 +84,7 @@ func NewHddOverrideCommand() *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(issueOverride, hosts, redfish.HddBootSourceOverrideTarget)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 	}
 	return c
@@ -99,7 +99,7 @@ func NewUEFIHttpOverrideCommand() *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(issueOverride, hosts, redfish.UefiHTTPBootSourceOverrideTarget)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 	}
 	return c
@@ -114,7 +114,7 @@ func NewNoneOverrideCommand() *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(issueOverride, hosts, redfish.NoneBootSourceOverrideTarget)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 	}
 	return c

--- a/pkg/cmd/cli/chassis/boot/show.go
+++ b/pkg/cmd/cli/chassis/boot/show.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),
@@ -48,7 +48,7 @@ func NewShowCommand() *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := query.Async(getBootInformation, hosts)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 	}
 	return c

--- a/pkg/cmd/cli/chassis/chassis.go
+++ b/pkg/cmd/cli/chassis/chassis.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/cmd/cli/chassis/power/cycle.go
+++ b/pkg/cmd/cli/chassis/power/cycle.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),
@@ -59,7 +59,7 @@ Also allows bypassing the OS shutdown, forcing a warm boot.`,
 			}
 
 			content := set.Async(Issue, hosts, resetType)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 		Hidden: false,
 	}

--- a/pkg/cmd/cli/chassis/power/nmi.go
+++ b/pkg/cmd/cli/chassis/power/nmi.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),
@@ -42,7 +42,7 @@ func NewPowerNMICommand() *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(Issue, hosts, redfish.NmiResetType)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 		Hidden: false,
 	}

--- a/pkg/cmd/cli/chassis/power/off.go
+++ b/pkg/cmd/cli/chassis/power/off.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),
@@ -63,7 +63,7 @@ as well as a power-button emulated shutdown.`,
 			}
 
 			content := set.Async(Issue, hosts, resetType)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 	}
 	c.PersistentFlags().BoolP(

--- a/pkg/cmd/cli/chassis/power/on.go
+++ b/pkg/cmd/cli/chassis/power/on.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),
@@ -42,7 +42,7 @@ func NewPowerOnCommand() *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(Issue, hosts, redfish.OnResetType)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 	}
 	return c

--- a/pkg/cmd/cli/chassis/power/power.go
+++ b/pkg/cmd/cli/chassis/power/power.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/cmd/cli/chassis/power/reset.go
+++ b/pkg/cmd/cli/chassis/power/reset.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),
@@ -42,7 +42,7 @@ func NewPowerResetCommand() *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := set.Async(Issue, hosts, redfish.ForceRestartResetType)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 		Hidden: false,
 	}

--- a/pkg/cmd/cli/chassis/power/status.go
+++ b/pkg/cmd/cli/chassis/power/status.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),
@@ -42,7 +42,7 @@ func NewPowerStatusCommand() *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := query.Async(status, hosts)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 		Hidden: false,
 	}

--- a/pkg/cmd/cli/print.go
+++ b/pkg/cmd/cli/print.go
@@ -1,0 +1,209 @@
+/*
+
+ MIT License
+
+ (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+package cli
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/viper"
+	"gopkg.in/yaml.v3"
+	"reflect"
+	"sort"
+)
+
+// keyValuePrint is a print helper for formatting key-value pairs.
+func keyValuePrint(key string, value any, indent string) {
+	fmt.Printf("%s%-60s: %-60v\n", indent, key, value)
+}
+
+// keyPrint is a print helper for printing just a key in anticipation of printing a data structure as a value.
+func keyPrint(key string, indent string) {
+	fmt.Printf("%s%s:\n", indent, key)
+}
+
+// sliceElementPrint is a print helper for printing values belonging to an array in a marked up format.
+func sliceElementPrint(value any, indent string) {
+	fmt.Printf("%s%-60v\n", indent, value)
+}
+
+// slicePrint is a print helper for printing a slice of interfaces.
+func slicePrint(value reflect.Value) {
+
+	for i := 0; i < value.Len(); i++ {
+
+		sv := reflect.ValueOf(value.Index(i).Interface())
+		keyPrint(fmt.Sprintf("%d", i), "\t")
+
+		for k := 0; k < sv.NumField(); k++ {
+
+			typeOfS := sv.Type()
+
+			if sv.Field(k).Interface() == nil {
+
+				continue
+
+			}
+
+			kind := reflect.TypeOf(sv.Field(k).Interface()).Kind()
+
+			if kind == reflect.Slice {
+
+				keyPrint(typeOfS.Field(k).Name, "\t")
+
+				// FIXME: This does not increase indent level.
+				slicePrint(sv.Field(k))
+
+			} else {
+				keyValuePrint(typeOfS.Field(k).Name, sv.Field(k), "\t\t")
+			}
+		}
+	}
+}
+
+// structPrint is a print helper for printing a map.
+func structPrint(value reflect.Value) {
+
+	typeOfS := value.Type()
+
+	for i := 0; i < value.NumField(); i++ {
+
+		if value.Field(i).Interface() == nil {
+
+			continue
+
+		} else if _, ok := value.Field(i).Interface().(map[string]interface{}); ok {
+
+			keys := value.Field(i).MapKeys()
+
+			if len(keys) != 0 {
+
+				keyPrint(typeOfS.Field(i).Name, "\t")
+
+			} else {
+
+				continue
+
+			}
+
+			sortedKeys := make([]string, 0, len(keys))
+
+			for key := range keys {
+
+				sortedKeys = append(sortedKeys, keys[key].String())
+
+			}
+
+			sort.Strings(sortedKeys)
+
+			for key := range sortedKeys {
+
+				keyValuePrint(sortedKeys[key], value.Field(i).MapIndex(reflect.ValueOf(sortedKeys[key])), "\t\t")
+
+			}
+
+		} else if _, ok := value.Field(i).Interface().([]string); ok {
+
+			keyPrint(typeOfS.Field(i).Name, "\t")
+
+			for _, v := range value.Field(i).Interface().([]string) {
+
+				sliceElementPrint(v, "\t\t")
+
+			}
+
+		} else {
+			if value.Field(i).Interface() == nil || value.Field(i).Interface() == "" {
+
+				continue
+
+			}
+			if reflect.TypeOf(value.Field(i).Interface()).Kind() == reflect.Slice {
+
+				slicePrint(value.Field(i))
+
+			}
+
+			keyValuePrint(typeOfS.Field(i).Name, value.Field(i).Interface(), "\t")
+
+		}
+	}
+}
+
+// PrettyPrint prints output in a human-readable manner, unless a specific format is given (e.g. `--json` or `--yaml`).
+func PrettyPrint(content map[string]interface{}) {
+	if viper.GetBool("json") {
+
+		JSON, err := json.MarshalIndent(content, "", "  ")
+		if err != nil {
+			panic(fmt.Errorf("could not create valid JSON from %v", content))
+		}
+		fmt.Printf("%s\n", string(JSON))
+
+	} else if viper.GetBool("yaml") {
+
+		YAML, err := yaml.Marshal(content)
+		if err != nil {
+			panic(fmt.Errorf("could not create valid YAML from %v", content))
+		}
+		fmt.Printf("%s\n", string(YAML))
+
+	} else {
+
+		keys := make([]string, 0, len(content))
+
+		for k := range content {
+
+			keys = append(keys, k)
+
+		}
+
+		sort.Strings(keys)
+
+		for _, k := range keys {
+
+			fmt.Printf("%s:\n", k)
+
+			// Warning; the struct fields must be exported!
+			s := content[k]
+			v := reflect.ValueOf(s)
+
+			if reflect.TypeOf(v.Interface()).Kind() == reflect.Slice {
+
+				slicePrint(v)
+
+			} else if reflect.TypeOf(v.Interface()).Kind() == reflect.Struct {
+
+				structPrint(v)
+
+			} else {
+
+				fmt.Println("Shouldn't be here.")
+
+			}
+		}
+	}
+}

--- a/pkg/cmd/cli/proc/proc.go
+++ b/pkg/cmd/cli/proc/proc.go
@@ -24,26 +24,20 @@
 
 */
 
-package show
+package proc
 
-import (
-	"github.com/Cray-HPE/gru/pkg/cmd/cli/chassis/boot"
-	"github.com/Cray-HPE/gru/pkg/cmd/cli/proc"
-	"github.com/Cray-HPE/gru/pkg/cmd/cli/system"
-	"github.com/spf13/cobra"
-)
+// Processors represents a list of Processor types.
+type Processors []Processor
 
-// NewCommand creates the `show` subcommand.
-func NewCommand() *cobra.Command {
-	c := &cobra.Command{
-		Use:   "show",
-		Short: "Curated server information",
-		Long:  `Print pre-defined classes of information from one or more BMCs`,
-	}
-	c.AddCommand(
-		boot.NewShowCommand(),
-		proc.NewShowCommand(),
-		system.NewShowCommand(),
-	)
-	return c
+// Processor represents a single, physical processor.
+// The processor's model number is stored in either Processor.Model or Processor.VendorID depending
+// on the vendor. The user may need to interpret both fields to understand what they have.
+type Processor struct {
+	Architecture string `json:"architecture" yaml:"architecture"`
+	TotalCores   int    `json:"totalCores" yaml:"total_cores"`
+	Model        string `json:"model" yaml:"model"`
+	Socket       string `json:"socket" yaml:"socket"`
+	Threads      int    `json:"threads" yaml:"threads"`
+	VendorID     string `json:"vendorID" yaml:"vendor_id"`
+	Error        error  `json:"error,omitempty" yaml:"error,omitempty"`
 }

--- a/pkg/cmd/cli/proc/show.go
+++ b/pkg/cmd/cli/proc/show.go
@@ -1,0 +1,107 @@
+/*
+
+ MIT License
+
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+
+ Permission is hereby granted, free of charge, to any person obtaining a
+ copy of this software and associated documentation files (the "Software"),
+ to deal in the Software without restriction, including without limitation
+ the rights to use, copy, modify, merge, publish, distribute, sublicense,
+ and/or sell copies of the Software, and to permit persons to whom the
+ Software is furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included
+ in all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+ THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+ OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+package proc
+
+import (
+	"fmt"
+	"github.com/Cray-HPE/gru/internal/query"
+	"github.com/Cray-HPE/gru/pkg/auth"
+	"github.com/Cray-HPE/gru/pkg/cmd/cli"
+	"github.com/spf13/cobra"
+	"strings"
+)
+
+// NewShowCommand creates the `system` subcommand for `show`.
+func NewShowCommand() *cobra.Command {
+	c := &cobra.Command{
+		Use:   "proc host [...host]",
+		Short: "Processor information",
+		Long:  `Show the Server's processors, a full list with their core count, model, architecture, and serial numbers.`,
+		Run: func(c *cobra.Command, args []string) {
+			hosts := cli.ParseHosts(args)
+			content := query.Async(getProcessors, hosts)
+			cli.PrettyPrint(content)
+		},
+	}
+	return c
+}
+
+func getProcessors(host string) interface{} {
+	foundProcessors := Processors{}
+	c, err := auth.Connection(host)
+	if err != nil {
+		foundProcessors = append(
+			foundProcessors, Processor{
+				Error: err,
+			},
+		)
+		return foundProcessors
+	}
+	defer c.Logout()
+	service := c.Service
+
+	managers, err := service.Managers()
+	if err != nil || len(managers) < 1 {
+		foundProcessors = append(
+			foundProcessors, Processor{
+				Error: err,
+			},
+		)
+		return foundProcessors
+	}
+
+	systems, err := service.Systems()
+	if err != nil || len(systems) < 1 {
+		foundProcessors = append(
+			foundProcessors, Processor{
+				Error: err,
+			},
+		)
+		return foundProcessors
+	}
+	systemProcessors, err := systems[0].Processors()
+	if err != nil {
+		foundProcessors = append(
+			foundProcessors, Processor{
+				Error: err,
+			},
+		)
+	} else {
+		for i := range systemProcessors {
+			processor := Processor{
+				Architecture: strings.TrimSpace(fmt.Sprintf("%v", systemProcessors[i].ProcessorArchitecture)),
+				TotalCores:   systemProcessors[i].TotalCores,
+				Model:        strings.TrimSpace(systemProcessors[i].Model),
+				Socket:       strings.TrimSpace(systemProcessors[i].Socket),
+				Threads:      systemProcessors[i].TotalThreads,
+				VendorID:     strings.TrimSpace(systemProcessors[i].ProcessorID.VendorID),
+			}
+			foundProcessors = append(foundProcessors, processor)
+		}
+	}
+	return foundProcessors
+}

--- a/pkg/cmd/cli/show/show.go
+++ b/pkg/cmd/cli/show/show.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/cmd/cli/system/show.go
+++ b/pkg/cmd/cli/system/show.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),
@@ -43,7 +43,7 @@ func NewShowCommand() *cobra.Command {
 		Run: func(c *cobra.Command, args []string) {
 			hosts := cli.ParseHosts(args)
 			content := query.Async(getSystemInformation, hosts)
-			cli.MapPrint(content)
+			cli.PrettyPrint(content)
 		},
 	}
 	return c
@@ -72,9 +72,12 @@ func getSystemInformation(host string) interface{} {
 		system.Error = err
 		return system
 	}
+
+	system.BIOSVersion = strings.TrimSpace(systems[0].BIOSVersion)
 	system.Manufacturer = strings.TrimSpace(systems[0].Manufacturer)
 	system.Model = strings.TrimSpace(systems[0].Model)
-	system.BIOSVersion = strings.TrimSpace(systems[0].BIOSVersion)
 	system.ProcessorModel = strings.TrimSpace(systems[0].ProcessorSummary.Model)
+	system.SerialNumber = strings.TrimSpace(systems[0].SerialNumber)
+
 	return system
 }

--- a/pkg/cmd/cli/system/system.go
+++ b/pkg/cmd/cli/system/system.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),
@@ -33,5 +33,6 @@ type System struct {
 	ProcessorModel  string `json:"processorModel" yaml:"processor_model"`
 	Manufacturer    string `json:"manufacturer" yaml:"manufacturer"`
 	Model           string `json:"model" yaml:"model"`
+	SerialNumber    string `json:"serialNumber" yaml:"serial_number"`
 	Error           error  `json:"error,omitempty" yaml:"error,omitempty"`
 }

--- a/pkg/cmd/errors.go
+++ b/pkg/cmd/errors.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/cmd/gru/gru.go
+++ b/pkg/cmd/gru/gru.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -2,7 +2,7 @@
 
  MIT License
 
- (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+ (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 
  Permission is hereby granted, free of charge, to any person obtaining a
  copy of this software and associated documentation files (the "Software"),

--- a/spec/edge/edge_spec.sh
+++ b/spec/edge/edge_spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/functional/bios_get_attributes_spec.sh
+++ b/spec/functional/bios_get_attributes_spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permissioff is hereby granted, free of charge, to any persoff obtaining a
 # copy of this software and associated documentatioff files (the "Software"),

--- a/spec/functional/bios_get_spec.sh
+++ b/spec/functional/bios_get_spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permissioff is hereby granted, free of charge, to any persoff obtaining a
 # copy of this software and associated documentatioff files (the "Software"),

--- a/spec/functional/bios_set_attributes_spec.sh
+++ b/spec/functional/bios_set_attributes_spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permissioff is hereby granted, free of charge, to any persoff obtaining a
 # copy of this software and associated documentatioff files (the "Software"),

--- a/spec/functional/bios_set_spec.sh
+++ b/spec/functional/bios_set_spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permissioff is hereby granted, free of charge, to any persoff obtaining a
 # copy of this software and associated documentatioff files (the "Software"),

--- a/spec/functional/chassis_power_off_spec.sh
+++ b/spec/functional/chassis_power_off_spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permissioff is hereby granted, free of charge, to any persoff obtaining a
 # copy of this software and associated documentatioff files (the "Software"),

--- a/spec/functional/chassis_power_on_spec.sh
+++ b/spec/functional/chassis_power_on_spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/functional/chassis_power_status_spec.sh
+++ b/spec/functional/chassis_power_status_spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/functional/empty_spec.sh
+++ b/spec/functional/empty_spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/functional/show_proc_spec.sh
+++ b/spec/functional/show_proc_spec.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env sh
+# MIT License
+#
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+#
+# Permission is hereby granted, free of charge, to any person obtaining a
+# copy of this software and associated documentation files (the "Software"),
+# to deal in the Software without restriction, including without limitation
+# the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the
+# Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included
+# in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+# THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+# OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+# ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+# OTHER DEALINGS IN THE SOFTWARE.
+
+
+Describe 'gru show proc'
+
+BeforeAll use_valid_config
+BeforeAll use_valid_bios_attributes_file
+
+# getting all bios keys should return lots of output
+It "--config ${GRU_CONF} 127.0.0.1:5000"
+  When call ./gru show proc --config "${GRU_CONF}" 127.0.0.1:5000
+  The status should equal 0
+  # check for some arbitrary keys to ensure it is not junk
+  The stdout should include 'CPU 1'
+  The stdout should include 'CPU 2'
+  The lines of stderr should equal 1
+End
+
+End

--- a/spec/integration/integration_spec.sh
+++ b/spec/integration/integration_spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),

--- a/spec/spec_helper.sh
+++ b/spec/spec_helper.sh
@@ -1,7 +1,7 @@
 #
 # MIT License
 #
-# (C) Copyright 2023 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->

- Fixes: #42 

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->
Adds a new subcommand for printing out CPU information.

Additional changes:
- Breaks up the `MapPrint` function into separate, reusable functions in a new `print.go` file.
- Updates copyright headers

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
