### PR TITLE
Fixes 60 - `off` and `cycle`

### DIFF
--- a/pkg/cmd/cli/chassis/power/cycle.go
+++ b/pkg/cmd/cli/chassis/power/cycle.go
@@ -43,7 +43,6 @@ func NewPowerCycleCommand() *cobra.Command {
 		Short: "Power cycle the target machine(s)",
 		Long: `Performs an ACPI shutdown and startup to power cycle the target machine(s).
 Also allows bypassing the OS shutdown, forcing a warm boot.`,
-		Args: cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			var resetType redfish.ResetType
 

--- a/pkg/cmd/cli/chassis/power/off.go
+++ b/pkg/cmd/cli/chassis/power/off.go
@@ -44,7 +44,6 @@ func NewPowerOffCommand() *cobra.Command {
 		Long: `Powers off the target machine(s) with an ACPI shutdown.
 Permits forcing a shutdown (without waiting for the OS),
 as well as a power-button emulated shutdown.`,
-		Args: cobra.MinimumNArgs(1),
 		Run: func(c *cobra.Command, args []string) {
 			var resetType redfish.ResetType
 

--- a/spec/functional/chassis_power_cycle_spec.sh
+++ b/spec/functional/chassis_power_cycle_spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # MIT License
 #
-# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
 #
 # Permissioff is hereby granted, free of charge, to any persoff obtaining a
 # copy of this software and associated documentatioff files (the "Software"),
@@ -22,56 +22,35 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 
-Describe 'gru chassis power off'
-
-# it should error if no config is present
-It '127.0.0.1:5000 (no config file)'
-  When call ./gru chassis power off 127.0.0.1:5000
-  The status should equal 1
-  The line 1 of stderr should include 'Asynchronously updating'
-  The stderr should include "An error occurred: no credentials provided, please provide a config file or environment variables"
-End
+Describe 'gru chassis power cycle'
 
 # Running against an active host with good credentials should succeed and show output
 It "--config ${GRU_CONF} 127.0.0.1:5000"
   BeforeCall use_valid_config
-  When call ./gru chassis power off --config "${GRU_CONF}" 127.0.0.1:5000
+  When call ./gru chassis power cycle --config "${GRU_CONF}" 127.0.0.1:5000
   The status should equal 0
   The line 1 of stderr should include 'Asynchronously updating'
   The line 1 of stdout should equal '127.0.0.1:5000:'
   The line 2 of stdout should include 'PreviousPowerState'
-  # powerstate can vary depending when test runs so more logic needed
-  # The line 3 of stdout should include 'Off' 
   The line 3 of stdout should include 'RequestedPowerState'
-  The line 3 of stdout should include 'GracefulShutdown'
-  The lines of stderr should equal 1
-End
-
-# immediately check the status of the same node, which should now be off
-It "--config ${GRU_CONF} 127.0.0.1:5000"
-  BeforeCall use_valid_config
-  When call ./gru chassis power status --config "${GRU_CONF}" 127.0.0.1:5000
-  The status should equal 0
-  The line 1 of stderr should include 'Asynchronously querying'
-  The line 1 of stdout should equal '127.0.0.1:5000:'
-  The line 2 of stdout should include 'PowerState'
-  The line 2 of stdout should include 'Off'
+  The line 3 of stdout should include 'GracefulRestart'
   The lines of stderr should equal 1
 End
   
 # validate piping to STDIN works
-It "--config ${GRU_CONF}"
+It "--config ${GRU_CONF} (via STDIN)"
   BeforeCall use_valid_config
   
   Data "127.0.0.1:5000" # STDIN
 
-  When call ./gru chassis power off --config "${GRU_CONF}"
+  When call ./gru chassis power cycle --config "${GRU_CONF}"
   The status should equal 0
   The line 1 of stderr should include 'Asynchronously updating'
   The line 1 of stdout should equal '127.0.0.1:5000:'
   The line 2 of stdout should include 'PowerState'
-  The line 2 of stdout should include 'Off'
-  The lines of stdout should equal 3
+  The line 3 of stdout should include 'GracefulRestart'
+  The line 4 of stdout should include "reset type 'GracefulRestart' is not supported by this service"
+  The lines of stderr should equal 1
 End
 
 End


### PR DESCRIPTION
`power off` and `power cycle` had `Args: cobra.MinimumNArgs(1)` set. This was previously removed for several other commands because it broke piping.

When piping occurs, at least with how `gru` accepts piped arguments, the `args[]` slice is empty. In order for piping to work, we can not set a minimum number of arguments.

There may be another way to handle piping, assuming there's a way to get in front of Cobra.
