### PR TITLE
fix shellspec by pinning a commit before it broke

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: shellspec
+        ref: 38eee75cc2192160e0c7e858616aebd5043fbb5f # revert to avoid: 'prechecker.sh: line 66: 9: Bad file descriptor'
         repository: shellspec/shellspec
         fetch-depth: 0
 


### PR DESCRIPTION
Fixes shellspec tests temporarily by reverting to a commit prior to when it broke this flow.