### PR TITLE
use a StringSlice for bios attributes to properly parse and display them

### DIFF
--- a/pkg/cmd/cli/bios/bios.go
+++ b/pkg/cmd/cli/bios/bios.go
@@ -28,15 +28,16 @@ package bios
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+
 	"github.com/Cray-HPE/gru/pkg/auth"
 	"github.com/Cray-HPE/gru/pkg/cmd/cli/bios/collections"
 	"github.com/spf13/cobra"
 	"github.com/stmcginnis/gofish/redfish"
 	"gopkg.in/yaml.v3"
-	"os"
-	"path/filepath"
-	"regexp"
-	"strings"
 )
 
 // Settings is a structure for holding current BIOS attributes, pending attributes, and errors.
@@ -64,7 +65,7 @@ func NewCommand() *cobra.Command {
 		},
 	}
 
-	c.PersistentFlags().StringArrayVarP(
+	c.PersistentFlags().StringSliceVarP(
 		&Attributes,
 		"attributes",
 		"a",

--- a/spec/functional/bios_get_attributes_spec.sh
+++ b/spec/functional/bios_get_attributes_spec.sh
@@ -58,7 +58,7 @@ It "--config ${GRU_CONF} --attributes ProcessorHyperThreadingDisable,SRIOVEnable
   The status should equal 0
   The stdout should include 'ProcessorHyperThreadingDisable'
   The stdout should include 'SRIOVEnable'
-  The lines of stdout should equal 3
+  The lines of stdout should equal 4
   The lines of stderr should equal 1
 End
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->

When querying multiple bios attributes, separated by commas, they would be interpreted as a single key:

```
gru --config "${GRU_CONF}" bios get --attributes  Key1,Key2 127.0.0.1:5000 
Asynchronously querying [    1] hosts ... 
127.0.0.1:5000:
        Attributes:
                Key1,Key2                                                   : <nil>
```


This fixes that to show each key independently:

```
gru --config "${GRU_CONF}" bios get --attributes  Key1,Key2 127.0.0.1:5000 
Asynchronously querying [    1] hosts ... 
127.0.0.1:5000:
        Attributes:
                Key1                                                        : <nil>
                Key2                                                        : <nil>
```

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request
- Docs Pull Request
- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!--- Example:

This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
is resolved and the overall risk of fatal failures is reduced.

-->
