### PR TITLE
pin shellspec to a specific version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: shellspec
-        ref: 38eee75cc2192160e0c7e858616aebd5043fbb5f # revert to avoid: 'prechecker.sh: line 66: 9: Bad file descriptor'
+        ref: c209cb49a60b2a7727632373caf37e98649104f7 # pins at a specific commit for stability
         repository: shellspec/shellspec
         fetch-depth: 0
 


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->

The problem worked around in #65 was fixed with https://github.com/shellspec/shellspec/commit/c209cb49a60b2a7727632373caf37e98649104f7 so pin that as the latest stable version.

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request


### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->

Low.
