### PR TITLE
Parameterize shellspec tests to run against all vendors/models

### DIFF
--- a/spec/functional/bios_get_spec.sh
+++ b/spec/functional/bios_get_spec.sh
@@ -22,66 +22,55 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 
-Describe 'gru bios get'
-
+Describe "gru --config ${GRU_CONF} bios get"
 BeforeAll use_valid_config
 BeforeAll use_valid_bios_attributes_file
 
-# getting all bios keys should return lots of output
-It "--config ${GRU_CONF} 127.0.0.1:5000"
-  When call ./gru bios get --config "${GRU_CONF}" 127.0.0.1:5000
-  The status should equal 0
-  # check for some arbitrary keys to ensure it is not junk
-  The stdout should include 'ProcessorHyperThreadingDisable'
-  The stdout should include 'SRIOVEnable'
-  The stdout should include 'VTdSupport'
-  The lines of stdout should equal 866
-  The lines of stderr should equal 1
+# test all vendors running in different containers with different ports (see testdata/fixtures/rie)
+Parameters
+  # Hostname:Port    
+  # $1               $2      $3                                         $4     $5                      $6
+  127.0.0.1:5000     "866"   '"Attributes" does not exist or is null'   "2"    "ProcessorVmxEnable"    "ProcessorX2apic"
+  127.0.0.1:5001     "552"   "The resource at the URI"                  "19"   ""                      ""
+  # 127.0.0.1:5002  
+  127.0.0.1:5003     "20"    "The resource at the URI"                  "19"   ""                      ""
+  # 127.0.0.1:5004
 End
 
-# TODO: restore when args work with piping
-# # neglecting to add a host as an arg should fail with instructions
-# It "--config ${GRU_CONF}"
-#   When call ./gru --config "${GRU_CONF}" bios get
-#   The status should equal 1
-#   The stderr should include 'Error: requires at least 1 arg(s), only received 0'
-# End
+# getting all bios keys should return lots of output and will vary by vendor/model
+It "$1"
+  When call ./gru --config "${GRU_CONF}" bios get "$1"
+  The status should equal 0
+  The lines of stdout should equal "${2}" 
+  The lines of stderr should equal 1
+End
 
 # getting pending changes should return an error if the Bios/Settings.Attributes does not exist
-It "--config ${GRU_CONF} --pending 127.0.0.1:5000"
-  When call ./gru bios get --config "${GRU_CONF}" --pending 127.0.0.1:5000
+It "$1 --pending"
+  When call ./gru --config "${GRU_CONF}" bios get "$1" --pending 
   The status should equal 0
-  The stdout should include 'Error'
-  The stdout should include '"Attributes" does not exist or is null, the BIOS/firmware may need to updated for proper Attributes support'
-  The lines of stdout should equal 2
+  The stdout should include "${3}"
+  The lines of stdout should equal "${4}"
   The lines of stderr should equal 1
 End
 
-# TODO: restore when marshaling JSON errors is fixed.
-# getting pending changes should return an error if the Bios/Settings.Attributes does not exist and be valid json
-#It "--config ${GRU_CONF} --pending 127.0.0.1:5000 --json"
-#  When call ./gru bios get --config "${GRU_CONF}" --pending 127.0.0.1:5000 --json
-#  The status should equal 0
-#  The stdout should include 'error'
-#  The stdout should include '\"Attributes\" does not exist or is null, the BIOS/firmware may need to updated for proper Attributes support'
-#  The stdout should be_json
-#  The lines of stderr should equal 0
-#End
-
-# TODO: restore when marshaling YAML errors is fixed.
-# getting pending changes should return an error if the Bios/Settings.Attributes does not exist and be valid yaml
-#It "--config ${GRU_CONF} --pending 127.0.0.1:5000 --yaml"
-#  When call ./gru bios get --config "${GRU_CONF}" --pending 127.0.0.1:5000 --yaml
-#  The status should equal 0
-#  The stdout should include 'error'
-#  The stdout should include '\"Attributes\" does not exist or is null, the BIOS/firmware may need to updated for proper Attributes support'
-#  The stdout should be_yaml
-#  The lines of stderr should equal 1
-#End
+# validate yaml and json outputs work
+It "$1 --pending --yaml"
+  When call ./gru --config "${GRU_CONF}" bios get "$1" --pending --yaml
+  The status should equal 0
+  The stderr should be present
+  The stdout should "be_yaml"
+End
+It "$1 --pending --json"
+  When call ./gru --config "${GRU_CONF}" bios get "$1" --pending --json
+  The status should equal 0
+  The stderr should be present
+  The stdout should "be_json"
+End
 
 # getting keys from a file should return those keys
-It "--config ${GRU_CONF} --from-file ${GRU_BIOS_KV} 127.0.0.1:5000"
-  When call ./gru bios get --config "${GRU_CONF}" --from-file "${GRU_BIOS_KV}" 127.0.0.1:5000
+It "$1 --from-file ${GRU_BIOS_KV}"
+  When call ./gru --config "${GRU_CONF}" bios get "$1" --from-file "${GRU_BIOS_KV}"
   The status should equal 0
   The stdout should include 'BootTimeout'
   The stdout should include 'SRIOVEnable'
@@ -89,89 +78,55 @@ It "--config ${GRU_CONF} --from-file ${GRU_BIOS_KV} 127.0.0.1:5000"
   The lines of stderr should equal 1
 End
 
-# getting keys from a file should return those keys and be valid json
-It "--config ${GRU_CONF} --from-file ${GRU_BIOS_KV} 127.0.0.1:5000 --json"
-  When call ./gru bios get --config "${GRU_CONF}" --from-file "${GRU_BIOS_KV}" 127.0.0.1:5000 --json
+# validate yaml and json outputs work
+It "$1 --from-file ${GRU_BIOS_KV} --yaml"
+  When call ./gru --config "${GRU_CONF}" bios get "$1" --from-file "${GRU_BIOS_KV}" --yaml
   The status should equal 0
-  The stdout should include 'BootTimeout'
-  The stdout should include 'SRIOVEnable'
-  The lines of stderr should equal 1
-  The stdout should be_json
+  The stderr should be present
+  The stdout should "be_yaml"
 End
-
-# getting keys from a file should return those keys and be valid yaml
-It "--config ${GRU_CONF} --from-file ${GRU_BIOS_KV} 127.0.0.1:5000 --yaml"
-  When call ./gru bios get --config "${GRU_CONF}" --from-file "${GRU_BIOS_KV}" 127.0.0.1:5000 --yaml
+It "$1 --from-file ${GRU_BIOS_KV} --json"
+  When call ./gru --config "${GRU_CONF}" bios get "$1" --from-file "${GRU_BIOS_KV}" --json
   The status should equal 0
-  The stdout should include 'BootTimeout'
-  The stdout should include 'SRIOVEnable'
-  The lines of stderr should equal 1
-  The stdout should be_yaml
+  The stderr should be present
+  The stdout should "be_json"
 End
 
-# passing a shortcut should return a limited set of pre-defined keys
-It "--config ${GRU_CONF} --virtualization 127.0.0.1:5003"
-  When call ./gru bios get --config "${GRU_CONF}" --virtualization 127.0.0.1:5003
+
+# re-enable after https://github.com/Cray-HPE/csm-redfish-interface-emulator/pull/10 merges
+# # passing a shortcut should return a limited set of pre-defined keys
+# It "$1 --virtualization"
+#   When call ./gru bios get --config "${GRU_CONF}" "$1" --virtualization
+#   The status should equal 0
+#   The stdout should include "${5}"
+#   The stdout should include "${6}"
+#   The lines of stderr should equal 1
+# End
+
+# # validate yaml and json outputs work
+# It "$1 --virtualization --yaml"
+#   When call ./gru --config "${GRU_CONF}" bios get "$1" --virtualization --yaml
+#   The status should equal 0
+#   The stderr should be present
+#   The stdout should "be_yaml"
+# End
+# It "$1 --virtualization --json"
+#   When call ./gru --config "${GRU_CONF}" bios get "$1" --virtualization --json
+#   The status should equal 0
+#   The stderr should be present
+#   The stdout should "be_json"
+# End
+
+
+# also check that stdin works for this command, just checking that output exists
+Data:expand
+ #| $1
+End
+It "$1 --pending (host passed via STDIN)"
+  When call ./gru --config "${GRU_CONF}" bios get
   The status should equal 0
-  The stdout should include 'ProcAmdIOMMU'
-  The stdout should include 'Sriov'
-  The stdout should include 'ProcAmdVirtualization'
-  The lines of stdout should equal 6
-  The lines of stderr should equal 1
-End
-
-# passing a shortcut should return a limited set of pre-defined keys and be valid json
-It "--config ${GRU_CONF} --virtualization 127.0.0.1:5003 --json"
-  When call ./gru bios get --config "${GRU_CONF}" --virtualization 127.0.0.1:5003 --json
-  The status should equal 0
-  The stdout should include 'ProcAmdIOMMU'
-  The stdout should include 'ProcAmdVirtualization'
-  The stdout should include 'Sriov'
-  The lines of stderr should equal 1
-  The stdout should be_json
-End
-
-# passing a shortcut should return a limited set of pre-defined keys and be valid yaml
-It "--config ${GRU_CONF} --virtualization 127.0.0.1:5003 --yaml"
-  When call ./gru bios get --config "${GRU_CONF}" --virtualization 127.0.0.1:5003 --yaml
-  The status should equal 0
-  The stdout should include 'ProcAmdIOMMU'
-  The stdout should include 'ProcAmdVirtualization'
-  The stdout should include 'Sriov'
-  The lines of stderr should equal 1
-  The stdout should be_yaml
-End
-
-# piping in hosts should also work (json)
-Describe 'validate STDIN works'
-  Data
-    #|host1 127.0.0.1:5003
-  End
-  It "echo 127.0.0.1:5003 | --config ${GRU_CONF} --virtualization 127.0.0.1:5003 --json"
-    When call ./gru bios get --config "${GRU_CONF}" --virtualization 127.0.0.1:5003 --json
-    The status should equal 0
-    The stdout should include 'ProcAmdIOMMU'
-    The stdout should include 'ProcAmdVirtualization'
-    The stdout should include 'Sriov'
-    The lines of stderr should equal 1
-    The stdout should be_json
-  End
-End
-
-# piping in hosts should also work (yaml)
-Describe 'validate STDIN works'
-  Data
-    #|host1 127.0.0.1:5003
-  End
-  It "echo 127.0.0.1:5003 | --config ${GRU_CONF} --virtualization 127.0.0.1:5003 --yaml"
-    When call ./gru bios get --config "${GRU_CONF}" --virtualization 127.0.0.1:5003 --yaml
-    The status should equal 0
-    The stdout should include 'ProcAmdIOMMU'
-    The stdout should include 'ProcAmdVirtualization'
-    The stdout should include 'Sriov'
-    The stdout should be_yaml
-    The lines of stderr should equal 1
-  End
+  The stderr should be present
+  The stdout should be present
 End
 
 End

--- a/spec/functional/chassis_power_status_spec.sh
+++ b/spec/functional/chassis_power_status_spec.sh
@@ -22,23 +22,51 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 
-Describe 'gru chassis power status'
+Describe "gru --config ${GRU_CONF} chassis power status"
+BeforeAll use_valid_config
+BeforeAll use_valid_bios_attributes_file
 
-# it should error if no config is present
-It '127.0.0.1:5000 (no config file)'
-  When call ./gru chassis power status 127.0.0.1:5000
-  The status should equal 1
-  The line 1 of stderr should include 'Asynchronously querying'
-  The stderr should include "An error occurred: no credentials provided, please provide a config file or environment variables"
+# test all vendors/models (see testdata/fixtures/rie) as their outputs vary
+Parameters
+  127.0.0.1:5000
+  127.0.0.1:5001
+  127.0.0.1:5002 
+  127.0.0.1:5003
+  127.0.0.1:5004
 End
 
-# Running against an active host with good credentials should succeed and report the status
-It "--config ${GRU_CONF} 127.0.0.1:5000"
-  BeforeCall use_valid_config
-  When call ./gru chassis power status --config "${GRU_CONF}" 127.0.0.1:5000
+# the proc names vary by vendor/model, so check them according to the parameters
+It "$1"
+  When call ./gru --config "${GRU_CONF}" chassis power status "$1"
   The status should equal 0
-  The line 1 of stderr should include 'Asynchronously querying'
-  The line 1 of stdout should equal '127.0.0.1:5000:'
+  The line 1 of stdout should include "$1:" # the host should be in the stdout
+  The line 2 of stdout should include "PowerState" # the power state may vary, but check for the word 'PowerState'
+  The lines of stderr should equal 1
+End
+
+# validate yaml and json outputs work
+It "$1 --yaml"
+  When call ./gru --config "${GRU_CONF}" chassis power status "$1" "--yaml"
+  The status should equal 0
+  The stderr should be present
+  The stdout should "be_yaml"
+End
+It "$1 --json"
+  When call ./gru --config "${GRU_CONF}" chassis power status "$1" "--json"
+  The status should equal 0
+  The stderr should be present
+  The stdout should "be_json"
+End
+
+# also check that stdin works for this command, just checking that output exists
+Data:expand
+ #| $1
+End
+It "$1 (host passed via STDIN)"
+  When call ./gru --config "${GRU_CONF}" chassis power status
+  The status should equal 0
+  The stderr should be present
+  The stdout should be present
 End
 
 End

--- a/spec/functional/empty_spec.sh
+++ b/spec/functional/empty_spec.sh
@@ -22,13 +22,66 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 
-Describe 'gru <empty>'
-
-# no hosts should exit
-It "--config ${GRU_CONF} show system"
-  When call ./gru show system --config "${GRU_CONF}"
-  The status should equal 1
-  The stderr should include 'no hosts given'
+# TODO: use Parameters:dynamic to get all sub commands recursively
+# check 'bios' and sub-commands with no hosts given
+Describe "gru --config ${GRU_CONF}"
+Parameters:matrix
+  "bios"
+  "get"
+End
+It "$1 $2 (no hosts given)"
+  When call ./gru --config "${GRU_CONF}" "$1" "$2"
+  The status should equal 1 # no hosts should error
+  The stderr should include 'no hosts given' 
 End
 
+# it should error if no attributes are passed to the flag
+It "127.0.0.1 --attributes"
+  When call ./gru "$1" "$2" --config "${GRU_CONF}" "127.0.0.1" --attributes
+  The status should equal 1
+  The stderr should include 'flag needs an argument: --attributes'
+End
+
+
+End
+
+# check 'chassis boot' and sub-commands with no hosts given
+Describe "gru --config ${GRU_CONF} chassis"
+Parameters:matrix 
+  "boot"
+  "bios" "hdd" "http" "none" "pxe"
+End
+It "$1 $2 (no hosts given)"
+  When call ./gru --config "${GRU_CONF}" "chassis" "$1" "$2"
+  The status should equal 1 # no hosts should error
+  The stdout should be defined
+  The stderr should include 'no hosts given'
+End
+End
+
+# check 'chassis power' and sub-commands with no hosts given
+Describe "gru --config ${GRU_CONF} chassis"
+Parameters:matrix
+  "power"
+  "cycle" "nmi" "off" "on" "reset" "status"
+End
+It "$1 $2 (no hosts given)"
+  When call ./gru --config "${GRU_CONF}" "chassis" "$1" "$2"
+  The status should equal 1 # no hosts should error
+  The stdout should be defined
+  The stderr should include 'no hosts given'
+End
+End
+
+# check 'show' and sub-commands with no hosts given
+Describe "gru --config ${GRU_CONF}"
+Parameters:matrix
+  "show"
+  "boot" "proc" "system"
+End
+It "$1 $2 (no hosts given)"
+  When call ./gru --config "${GRU_CONF}" "$1" "$2"
+  The status should equal 1 # no hosts should error
+  The stderr should include 'no hosts given'
+End
 End

--- a/spec/functional/show_system_spec.sh
+++ b/spec/functional/show_system_spec.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env sh
 # MIT License
 #
-# (C) Copyright 2024 Hewlett Packard Enterprise Development LP
+# (C) Copyright 2023-2024 Hewlett Packard Enterprise Development LP
 #
 # Permission is hereby granted, free of charge, to any person obtaining a
 # copy of this software and associated documentation files (the "Software"),
@@ -22,37 +22,37 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 
 
-Describe "gru show proc --config ${GRU_CONF}"
+Describe "gru --config ${GRU_CONF} show system"
 BeforeAll use_valid_config
 BeforeAll use_valid_bios_attributes_file
 
 # test all vendors/models (see testdata/fixtures/rie) as their outputs vary
 Parameters
-  127.0.0.1:5000    "CPU 1"     "CPU 2"   
-  127.0.0.1:5001    "P1"        "P1"      
-  127.0.0.1:5002    "Proc 1"    ""       
-  127.0.0.1:5003    "CPU 0"     "CPU 1"   
-  127.0.0.1:5004    "Proc 1"    "Proc 2"  
+  # $1              $2
+  127.0.0.1:5000    "S2600BPB"                   
+  127.0.0.1:5001    "H262-Z63-00"                
+  127.0.0.1:5002    "ProLiant DL325 Gen10 Plus" 
+  127.0.0.1:5003    "HPE CRAY EX425 (MILAN)"     
+  127.0.0.1:5004    "ProLiant XL675d Gen10 Plus" 
 End
 
-# the proc names vary by vendor/model, so check them according to the parameters
+# check the model number as it will vary by vendor/model
 It "$1"
-  When call ./gru --config "${GRU_CONF}" show proc "$1"
+  When call ./gru --config "${GRU_CONF}" show system "$1"
   The status should equal 0
   The stdout should include "$2"
-  The stdout should include "$3"
   The lines of stderr should equal 1
 End
 
 # validate yaml and json outputs work
 It "$1 --yaml"
-  When call ./gru --config "${GRU_CONF}" show proc "$1" "--yaml"
+  When call ./gru --config "${GRU_CONF}" show system "$1" "--yaml"
   The status should equal 0
   The stderr should be present
   The stdout should "be_yaml"
 End
 It "$1 --json"
-  When call ./gru --config "${GRU_CONF}" show proc "$1" "--json"
+  When call ./gru --config "${GRU_CONF}" show system "$1" "--json"
   The status should equal 0
   The stderr should be present
   The stdout should "be_json"
@@ -63,7 +63,7 @@ Data:expand
  #| $1
 End
 It "$1 (host passed via STDIN)"
-  When call ./gru --config "${GRU_CONF}" show proc
+  When call ./gru --config "${GRU_CONF}" show system
   The status should equal 0
   The stderr should be present
   The stdout should be present


### PR DESCRIPTION
and make maintainability easier.  This relies on two shellspec features:

1. [Parameters](https://github.com/shellspec/shellspec?tab=readme-ov-file#parameters---parameterized-example), where you can define several params and it will execute the same tests against them
2. [Data](https://github.com/shellspec/shellspec?tab=readme-ov-file#data---pass-data-as-stdin-to-evaluation), which passes parameters in as STDIN, which is a vital feature of gru

Within the tests, I set parameters for each container running in the simulator.  In some tests, I add additional ones where the output of commands vary depending upon the endpoint being targeted.

There are some commented out tests, which require an updated in the emulator: https://github.com/Cray-HPE/csm-redfish-interface-emulator/pull/10
