### PR TITLE
update emulator to new image with correct vendor for Intel and re-enable disabled tests

### DIFF
--- a/spec/functional/bios_get_spec.sh
+++ b/spec/functional/bios_get_spec.sh
@@ -93,29 +93,28 @@ It "$1 --from-file ${GRU_BIOS_KV} --json"
 End
 
 
-# re-enable after https://github.com/Cray-HPE/csm-redfish-interface-emulator/pull/10 merges
-# # passing a shortcut should return a limited set of pre-defined keys
-# It "$1 --virtualization"
-#   When call ./gru bios get --config "${GRU_CONF}" "$1" --virtualization
-#   The status should equal 0
-#   The stdout should include "${5}"
-#   The stdout should include "${6}"
-#   The lines of stderr should equal 1
-# End
+# passing a shortcut should return a limited set of pre-defined keys
+It "$1 --virtualization"
+  When call ./gru bios get --config "${GRU_CONF}" "$1" --virtualization
+  The status should equal 0
+  The stdout should include "${5}"
+  The stdout should include "${6}"
+  The lines of stderr should equal 1
+End
 
-# # validate yaml and json outputs work
-# It "$1 --virtualization --yaml"
-#   When call ./gru --config "${GRU_CONF}" bios get "$1" --virtualization --yaml
-#   The status should equal 0
-#   The stderr should be present
-#   The stdout should "be_yaml"
-# End
-# It "$1 --virtualization --json"
-#   When call ./gru --config "${GRU_CONF}" bios get "$1" --virtualization --json
-#   The status should equal 0
-#   The stderr should be present
-#   The stdout should "be_json"
-# End
+# validate yaml and json outputs work
+It "$1 --virtualization --yaml"
+  When call ./gru --config "${GRU_CONF}" bios get "$1" --virtualization --yaml
+  The status should equal 0
+  The stderr should be present
+  The stdout should "be_yaml"
+End
+It "$1 --virtualization --json"
+  When call ./gru --config "${GRU_CONF}" bios get "$1" --virtualization --json
+  The status should equal 0
+  The stderr should be present
+  The stdout should "be_json"
+End
 
 
 # also check that stdin works for this command, just checking that output exists

--- a/testdata/fixtures/rie/docker-compose.simple.yaml
+++ b/testdata/fixtures/rie/docker-compose.simple.yaml
@@ -5,7 +5,7 @@ services:
 
   rfemulator0:
     hostname: x0c0b0
-    image: artifactory.algol60.net/csm-docker/stable/csm-rie:1.5.3
+    image: artifactory.algol60.net/csm-docker/stable/csm-rie:1.5.4
     environment:
       - MOCKUPFOLDER=Intel
       - XNAME=x0c0b0
@@ -16,7 +16,7 @@ services:
 
   rfemulator1:
     hostname: x0c0s1b0
-    image: artifactory.algol60.net/csm-docker/stable/csm-rie:1.5.3
+    image: artifactory.algol60.net/csm-docker/stable/csm-rie:1.5.4
     environment:
       - MOCKUPFOLDER=Gigabyte
       - XNAME=x0c0s1b0
@@ -27,7 +27,7 @@ services:
 
   rfemulator2:
     hostname: x0c0r2b0
-    image: artifactory.algol60.net/csm-docker/stable/csm-rie:1.5.3
+    image: artifactory.algol60.net/csm-docker/stable/csm-rie:1.5.4
     environment:
       - MOCKUPFOLDER=DL325
       - XNAME=x0c0r2b0
@@ -38,7 +38,7 @@ services:
 
   rfemulator3:
     hostname: x0c0r3b0
-    image: artifactory.algol60.net/csm-docker/stable/csm-rie:1.5.3
+    image: artifactory.algol60.net/csm-docker/stable/csm-rie:1.5.4
     environment:
       - MOCKUPFOLDER=EX425
       - XNAME=x0c0r3b0
@@ -49,7 +49,7 @@ services:
 
   rfemulator4:
     hostname: x0c0r4b0
-    image: artifactory.algol60.net/csm-docker/stable/csm-rie:1.5.3
+    image: artifactory.algol60.net/csm-docker/stable/csm-rie:1.5.4
     environment:
       - MOCKUPFOLDER=XL675d_A40
       - XNAME=x0c0r4b0


### PR DESCRIPTION


### Summary and Scope

<!--- Pick one below and delete the rest -->

Re-enables some tests that failed due to an invalid vendor key in the emulator.  The tests now work because the Intel mockup properly identifies itself as "Intel" instead of "Cray"

The csm-rie:1.5.3 image incorrectly identified the Intel mockup as a "Cray".  This is fixed in 1.5.4 by way of https://github.com/Cray-HPE/csm-redfish-interface-emulator/pull/10 and the vendor detection by gru now works with this emulator.

#### Issue Type

<!--- Delete un-needed bullets -->

- RFE Pull Request

<!--- words; describe what this change is and what it is for. -->

### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->

Low.

